### PR TITLE
fix: auth tokens not propagating to child requests

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -157,7 +157,7 @@ const toast = useToast()
 const props = withDefaults(
   defineProps<{
     show: boolean
-    loadingState: boolean
+    loadingState?: boolean
     editingProperties: EditingProperties
     source: "REST" | "GraphQL"
     modelValue: string

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2796,6 +2796,11 @@ const setCollectionProperties = (newCollection: {
   path: string
 }) => {
   const { collection, path, isRootCollection } = newCollection
+
+  // We default to using collection.id but during the callback to our application, collection.id is not being preserved.
+  // Since path is being preserved, we extract the collectionId from path instead
+  const collectionId = (collection?.id ?? path?.split("/").pop()) as string
+
   if (!collection) return
 
   if (collectionsType.value.type === "my-collections") {
@@ -2818,13 +2823,13 @@ const setCollectionProperties = (newCollection: {
       )
     })
     toast.success(t("collection.properties_updated"))
-  } else if (hasTeamWriteAccess.value && collection.id) {
+  } else if (hasTeamWriteAccess.value && collectionId) {
     const data = {
       auth: collection.auth,
       headers: collection.headers,
     }
     pipe(
-      updateTeamCollection(collection.id, JSON.stringify(data), undefined),
+      updateTeamCollection(collectionId, JSON.stringify(data), undefined),
       TE.match(
         (err: GQLError<string>) => {
           toast.error(`${getErrorMessage(err)}`)

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2797,11 +2797,11 @@ const setCollectionProperties = (newCollection: {
 }) => {
   const { collection, path, isRootCollection } = newCollection
 
+  if (!collection) return
+
   // We default to using collection.id but during the callback to our application, collection.id is not being preserved.
   // Since path is being preserved, we extract the collectionId from path instead
-  const collectionId = (collection?.id ?? path?.split("/").pop()) as string
-
-  if (!collection) return
+  const collectionId = collection?.id ?? path?.split("/").pop()
 
   if (collectionsType.value.type === "my-collections") {
     if (isRootCollection) {


### PR DESCRIPTION
## Context:

## What's Changed?
- `collection.id` is not preserved during callback to the application from oauth provider
- As such, the condition `hasTeamWriteAccess.value && collection.id` fails and access tokens are not preserved while saving collection properties - which causes auth inheritance to break in children requests
- Since path variable is always preserved, we use that to deduce collection.id instead

## Note to the reviewers
- This is happening in Team Workspaces only

**Video demonstrating the issue (site: hoppscotch.io):**


**Video demonstrating the fix (dev env):**

